### PR TITLE
Initial support for language profiles

### DIFF
--- a/load.pl
+++ b/load.pl
@@ -1,0 +1,1 @@
+:- [prolog/prolog_lsp].

--- a/prolog/jsonrpc/protocol.pl
+++ b/prolog/jsonrpc/protocol.pl
@@ -17,8 +17,8 @@
 :- use_module(library(log4p)).
 
 :- multifile
-  jsonrpc_protocol:on_message_read/1,
-  jsonrpc_protocol:on_message_write/1.
+  on_message_read/1,
+  on_message_write/1.
 
 read_message(In, Message) :-
   setup_and_call_cleanup(

--- a/prolog/jsonrpc/protocol.pl
+++ b/prolog/jsonrpc/protocol.pl
@@ -16,9 +16,8 @@
 
 :- use_module(library(log4p)).
 
-:- multifile
-  on_message_read/1,
-  on_message_write/1.
+:- multifile on_message_read/1.
+:- multifile on_message_write/1.
 
 read_message(In, Message) :-
   setup_and_call_cleanup(

--- a/prolog/pls_index.pl
+++ b/prolog/pls_index.pl
@@ -5,6 +5,7 @@
 :- reexport(pls_index/definitions).
 :- reexport(pls_index/docs).
 :- reexport(pls_index/documents).
+:- reexport(pls_index/profiles).
 :- reexport(pls_index/indexing).
 :- reexport(pls_index/references).
 :- reexport(pls_index/terms).

--- a/prolog/pls_index/definitions.pl
+++ b/prolog/pls_index/definitions.pl
@@ -19,6 +19,6 @@ get_definitions(Predicate, Definitions) :-
       uri: DefURI,
       range: DefRange
       }, 
-    get_document_item(DefURI, DefRange, defines(Predicate)), 
+    get_document_item(DefURI, DefRange, defines(Predicate)),
     Definitions
     ).

--- a/prolog/pls_index/docs.pl
+++ b/prolog/pls_index/docs.pl
@@ -12,19 +12,12 @@
 
 :- use_module(documents).
 
-index_docs(URI, _Module:Head :- Body, Range, CommentPos) :-
-  index_docs(URI, Head :- Body, Range, CommentPos).
-
-index_docs(URI, Head :- _Body, Range, CommentPos) :-
-  functor(Head, Name, Arity),
-  Predicate = Name/Arity,
+index_docs(URI, PredicateOrKey, Range, CommentPos) :-
   ( filter_for_docs(Range, CommentPos, DocLine, Docs)
-    -> add_document_item(URI, Range, docs(Predicate, DocLine, Docs))
+    -> add_document_item(URI, Range, docs(PredicateOrKey, DocLine, Docs))
     ; true
     ),
   !.
-
-index_docs(_URI, _Term, _Range, _CommentPos, _TermPos).
 
 %! filter_for_docs(+Range, +CommentPos, -DocLine, -Docs) is nondet.
 %

--- a/prolog/pls_index/docs.pl
+++ b/prolog/pls_index/docs.pl
@@ -26,6 +26,12 @@ index_docs(URI, Head :- _Body, Range, CommentPos) :-
 
 index_docs(_URI, _Term, _Range, _CommentPos, _TermPos).
 
+%! filter_for_docs(+Range, +CommentPos, -DocLine, -Docs) is nondet.
+%
+% Return the line where docs start and the docs (e.g., multi-line string 
+% comments) that precede the provided range. This separates comments
+% for documentation from comments that are interior to the definition,
+% and thus comments and not documentation.
 filter_for_docs(Range, CommentPos, DocLine, Docs) :-
   findall(
     Line-Comment,

--- a/prolog/pls_index/documents.pl
+++ b/prolog/pls_index/documents.pl
@@ -189,6 +189,13 @@ with_content(URI, In, Module:Goal) :-
 add_document_line(URI, Line, Position) :-
   assertz(document_line_position(URI, Line, Position)).
 
+%! get_document_line_position(+URI, ?Line, +Position) is det.
+%! get_document_line_position(?URI, ?Line, ?Position) is det.
+% 
+% Given a position with a file, return the line where the position occurs,
+% or the reverse. Can also be useful for iterating over the starting positions
+% of lines within a file.
+%
 get_document_line_position(URI, Line, Position) :-
   ground(Position),
   get_document_line_count(URI, Max),

--- a/prolog/pls_index/documents.pl
+++ b/prolog/pls_index/documents.pl
@@ -5,6 +5,7 @@
   add_document_property/2,
   set_document_property/2,
   get_document_property/2,
+  clear_document_property/2,
   clear_document_properties/1,
 
   get_document_uri/1,

--- a/prolog/pls_index/lines.plt
+++ b/prolog/pls_index/lines.plt
@@ -3,7 +3,10 @@
 :- use_module(lines).
 :- use_module(documents).
 
+:- use_module(library(log4p)).
+
 test(index_lines) :-
+  format("starting line indexing test~n"),
   uri_file_name(URI, 'test.pl'),
   index_lines(URI),
   findall(Count, get_document_line_count(URI, Count), [11]),

--- a/prolog/pls_index/profiles.pl
+++ b/prolog/pls_index/profiles.pl
@@ -100,6 +100,10 @@ index_goal(URI, Caller, GoalPos, Goal) :-
 %  -- position helpers --
 % 
 
+%! functor_range(+URI, +Pos, -Range) is det.
+%
+% Given the position of a term, return the range for the functor.
+%
 functor_range(URI, term_position(_From, _To, FFrom, FTo, _Subpos), Range) :-
   term_range(URI, FFrom, FTo, Range).
 
@@ -109,6 +113,12 @@ functor_range(URI, FFrom, FTo, Range) :-
 term_position_range(URI, term_position(From, To, _FFrom, _FTo, _Subpos), Range) :-
   term_range(URI, From, To, Range).
 
+%! term_range(+URI, +From, +To, -Range) is det.
+%
+% Given a From position and To position in the text of the document
+% specified by URI, return a Ranage, which expresses as a start / end 
+% pair of locations. Each location has a line number and character offset.
+% 
 term_range(URI, From, To, Range) :-
   get_document_line_position(URI, FromLine, From),
   get_document_line_position(URI, FromLine, FromStart),

--- a/prolog/pls_index/profiles.pl
+++ b/prolog/pls_index/profiles.pl
@@ -5,7 +5,7 @@
   set_document_profile/2,
 
   profile_index_term/4,
-  profile_index_comments/5,
+  profile_index_docs/5,
   profile_index_signature/5,
   profile_index_goal/6,
 
@@ -31,12 +31,12 @@ user:file_search_path(pls_language_profile,library(pls_language_profile)).
 % profile_index_term(Profile, URI, SubPos, Term)
 :- multifile profile_index_term/4.
 
-%! profile_index_comments(+Profile, +URI, +CommentPos, +TermPos) is nondet.
+%! profile_index_docs(+Profile, +URI, +SubPos, Term, +CommentPos) is nondet.
 %
-% Index the documentation for the term at the indicated TermPos,
+% Index the documentation for the term at the indicated SubPos,
 % using the CommentPos from an earlier `read_term/3` call.
 %
-:- multifile profile_index_comments/5.
+:- multifile profile_index_docs/5.
 
 % profile_index_signature(Profile, URI, SubPos, Term, Vars)
 :- multifile profile_index_signature/5.

--- a/prolog/pls_index/profiles.pl
+++ b/prolog/pls_index/profiles.pl
@@ -47,6 +47,12 @@ user:file_search_path(pls_language_profile,library(pls_language_profile)).
 % 
 :- multifile profile_index_goal/6.
 
+%! profile_end_of_file(Profile, URI) is nondet.
+%
+% Allow the profile to cleanup after indexing a file.
+%
+:- multifile profile_end_of_file/2.
+
 %! use_language_profile(+Profile) is det.
 %
 % Directive to indicate which language profile to use when indexing

--- a/prolog/pls_index/profiles.pl
+++ b/prolog/pls_index/profiles.pl
@@ -1,0 +1,39 @@
+:- module(pls_index_profiles, [
+  use_language_profile/1,
+  ensure_profile_loaded/1,
+  get_document_profile/2
+]).
+
+:- use_module(documents).
+
+user:file_search_path(pls_language_profile,library(pls_language_profile)).
+
+%! use_language_profile(+Profile) is det.
+%
+% Directive to indicate which language profile to use when indexing
+% source. The specified profile applies to the end of the file, or
+% until the next such directive.
+use_language_profile(_Profile).
+
+%! profile_loaded(+Profile) is det.
+%
+% Dynamic predicate to indicate a profile has been loaded
+:- dynamic profile_loaded/1.
+
+profile_module_file(Profile, ProfileModuleFile) :-
+  exists_source(pls_language_profile(Profile), ProfileModuleFile).
+
+ensure_profile_loaded(Profile) :-
+  profile_loaded(Profile), 
+  !.
+
+ensure_profile_loaded(Profile) :-
+  once(profile_module_file(Profile, ProfileModuleFile)),
+  ensure_loaded(ProfileModuleFile),
+  assertz(profile_loaded(Profile)).
+
+get_document_profile(URI, Profile) :-
+  get_document_property(URI,profile(Profile)),
+  !.
+
+get_document_profile(_URI, base).

--- a/prolog/pls_index/profiles.pl
+++ b/prolog/pls_index/profiles.pl
@@ -31,13 +31,20 @@ user:file_search_path(pls_language_profile,library(pls_language_profile)).
 % profile_index_term(Profile, URI, SubPos, Term)
 :- multifile profile_index_term/4.
 
-% profile_index_comments(Profile, URI, SubPos, Term, CommentPos)
+%! profile_index_comments(+Profile, +URI, +CommentPos, +TermPos) is nondet.
+%
+% Index the documentation for the term at the indicated TermPos,
+% using the CommentPos from an earlier `read_term/3` call.
+%
 :- multifile profile_index_comments/5.
 
 % profile_index_signature(Profile, URI, SubPos, Term, Vars)
 :- multifile profile_index_signature/5.
 
-% profile_index_goal(Profile, URI, Caller, GoalPos, Goal)
+%! profile_index_goal(+Profile, ?URI, ?Caller, ?SubPos, ?Goal) is nondet.
+% 
+% Index a goal for cross-referncing
+% 
 :- multifile profile_index_goal/6.
 
 %! use_language_profile(+Profile) is det.

--- a/prolog/pls_index/profiles.pl
+++ b/prolog/pls_index/profiles.pl
@@ -7,7 +7,7 @@
   profile_index_term/4,
   profile_index_docs/5,
   profile_index_signature/5,
-  profile_index_goal/6,
+  profile_index_goal/5,
 
   index_goals/4,
   index_goal/4,
@@ -45,7 +45,7 @@ user:file_search_path(pls_language_profile,library(pls_language_profile)).
 % 
 % Index a goal for cross-referncing
 % 
-:- multifile profile_index_goal/6.
+:- multifile profile_index_goal/5.
 
 %! profile_end_of_file(Profile, URI) is nondet.
 %

--- a/prolog/pls_index/profiles.pl
+++ b/prolog/pls_index/profiles.pl
@@ -7,8 +7,10 @@
   profile_index_term/4,
   profile_index_comments/5,
   profile_index_signature/5,
+  profile_index_goal/6,
 
   index_goals/4,
+  index_goal/4,
 
   functor_range/3,
   functor_range/4,
@@ -34,6 +36,9 @@ user:file_search_path(pls_language_profile,library(pls_language_profile)).
 
 % profile_index_signature(Profile, URI, SubPos, Term, Vars)
 :- multifile profile_index_signature/5.
+
+% profile_index_goal(Profile, URI, Caller, GoalPos, Goal)
+:- multifile profile_index_goal/6.
 
 %! use_language_profile(+Profile) is det.
 %
@@ -74,26 +79,9 @@ set_document_profile(URI, Profile) :-
 index_goals(URI, Caller, GoalPos, Goal) :-
   forall(index_goal(URI, Caller, GoalPos, Goal), true).
 
-index_goal(URI, Caller, parentheses_term_position(_From, _To, ContentPos), Goal) :-
-  index_goal(URI, Caller, ContentPos, Goal).
-
-index_goal(URI, Caller, term_position(_From, _To, FFrom, FTo, _Subpos), Goal) :-
-  functor_range(URI, FFrom, FTo, Range),
-  ( Caller = _Name // _Arity
-    -> ( functor(Goal, Name, Arity), Predicate = Name//Arity) 
-    ; ( functor(Goal, Name, Arity), Predicate = Name/Arity)
-    ),
-  Item = references(Caller, Predicate),
-  debug("Adding item %w",[Item]),
-  add_document_item(URI, Range, Item) .
-
-index_goal(URI, Caller, term_position(_From, _To, _FFrom, _FTo, Subpos), Goal) :-
-  functor(Goal, _Name, Arity),
-  between(1, Arity, Index),
-  arg(Index, Goal, Arg),
-  nth1(Index, Subpos, Pos),
-  index_goal(URI, Caller, Pos, Arg).
-
+index_goal(URI, Caller, GoalPos, Goal) :-
+  get_document_profile(URI, Profile),
+  profile_index_goal(Profile, URI, Caller, GoalPos, Goal).
 
 % 
 %  -- position helpers --

--- a/prolog/pls_index/profiles.pl
+++ b/prolog/pls_index/profiles.pl
@@ -1,7 +1,13 @@
 :- module(pls_index_profiles, [
   use_language_profile/1,
   ensure_profile_loaded/1,
-  get_document_profile/2
+  get_document_profile/2,
+
+  functor_range/3,
+  functor_range/4,
+  term_position_range/3,
+  term_range/4,
+  argument_positions/2
 ]).
 
 :- use_module(documents).
@@ -37,3 +43,36 @@ get_document_profile(URI, Profile) :-
   !.
 
 get_document_profile(_URI, base).
+
+% 
+%  -- helpers --
+% 
+
+functor_range(URI, term_position(_From, _To, FFrom, FTo, _Subpos), Range) :-
+  term_range(URI, FFrom, FTo, Range).
+
+functor_range(URI, FFrom, FTo, Range) :-
+  term_range(URI, FFrom, FTo, Range).
+
+term_position_range(URI, term_position(From, To, _FFrom, _FTo, _Subpos), Range) :-
+  term_range(URI, From, To, Range).
+
+term_range(URI, From, To, Range) :-
+  get_document_line_position(URI, FromLine, From),
+  get_document_line_position(URI, FromLine, FromStart),
+  get_document_line_position(URI, ToLine, To),
+  get_document_line_position(URI, ToLine, ToStart),
+  FromPosition is From - FromStart,
+  ToPosition is To - ToStart,
+  Range = range{
+    start: position{
+      line: FromLine,
+      character: FromPosition
+      }, 
+    end: position{
+      line: ToLine, 
+      character: ToPosition
+      }
+    }.
+
+argument_positions(term_position(_From, _To, _FFrom, _FTo, Subpos), Subpos).

--- a/prolog/pls_index/terms.pl
+++ b/prolog/pls_index/terms.pl
@@ -8,6 +8,7 @@
 
 :- use_module(documents).
 :- use_module(docs).
+:- use_module(profiles).
 
 % Index the terms in a file, including subterms.
 % A file or document is a sequence of terms, and
@@ -49,9 +50,9 @@ index_term(URI, Pos, (:- module(Module, Exports))) :-
   term_position_range(URI, Pos, Range),
   add_document_item(URI, Range, module(Module, Exports)),
   % Arg of :-, which is the term position for module
-  term_position_subpos(Pos, [DirectiveArgPos]),
+  argument_positions(Pos, [DirectiveArgPos]),
   % Args of module: first is the name, second is export list
-  term_position_subpos(DirectiveArgPos, [_,list_position(_,_,ExportPosList, _)]),
+  argument_positions(DirectiveArgPos, [_,list_position(_,_,ExportPosList, _)]),
   index_exports(URI, Exports, ExportPosList),
   !.
 
@@ -86,7 +87,7 @@ index_term(URI, Pos, (_Module:Head :- Body)) :-
 index_term(URI, Pos, (Head :- Body)) :-
   functor(Head, Name, Arity),
   Caller = Name/Arity,
-  term_position_subpos(Pos, [HeadPos, BodyPos]),
+  argument_positions(Pos, [HeadPos, BodyPos]),
   term_position_range(URI, HeadPos, Range),
   add_document_item(URI, Range, defines(Caller)),
   index_goals(URI, Caller, BodyPos, Body),
@@ -95,7 +96,7 @@ index_term(URI, Pos, (Head :- Body)) :-
 index_term(URI, Pos, (Head --> Body)) :-
   functor(Head, Name, Arity),
   Caller = Name//Arity,
-  term_position_subpos(Pos, [HeadPos, BodyPos]),
+  argument_positions(Pos, [HeadPos, BodyPos]),
   term_position_range(URI, HeadPos, Range),
   add_document_item(URI, Range, defines(Caller)),
   index_goals(URI, Caller, BodyPos, Body),
@@ -182,4 +183,4 @@ term_range(URI, From, To, Range) :-
       }
     }.
 
-term_position_subpos(term_position(_From, _To, _FFrom, _FTo, Subpos), Subpos).
+argument_positions(term_position(_From, _To, _FFrom, _FTo, Subpos), Subpos).

--- a/prolog/pls_index/terms.pl
+++ b/prolog/pls_index/terms.pl
@@ -43,7 +43,28 @@ process_term(URI, _SubPos, (:- use_language_profile(Profile)), _CommentPos, _Var
 process_term(URI, SubPos, Term, CommentPos, Vars) :-
   get_document_profile(URI, Profile),
   ensure_profile_loaded(Profile),
+  try_profile_index_term(Profile, URI, SubPos, Term),
+  try_profile_index_comments(Profile, URI, SubPos, Term, CommentPos),
+  try_profile_index_signature(Profile, URI, SubPos, Term, Vars),
+  !.
+
+try_profile_index_term(Profile, URI, SubPos, Term) :-
   pls_index_profiles:profile_index_term(Profile, URI, SubPos, Term),
+  !.
+
+try_profile_index_term(_Profile, URI, SubPos, Term) :-
+  pls_index_profiles:profile_index_term(base, URI, SubPos, Term).
+
+try_profile_index_comments(Profile, URI, SubPos, Term, CommentPos) :-
   pls_index_profiles:profile_index_comments(Profile, URI, SubPos, Term, CommentPos),
+  !.
+
+try_profile_index_comments(_Profile, URI, SubPos, Term, CommentPos) :-
+  pls_index_profiles:profile_index_comments(base, URI, SubPos, Term, CommentPos).
+
+try_profile_index_signature(Profile, URI, SubPos, Term, Vars) :-
   pls_index_profiles:profile_index_signature(Profile, URI, SubPos, Term, Vars),
   !.
+
+try_profile_index_signature(_Profile, URI, SubPos, Term, Vars) :-
+  pls_index_profiles:profile_index_signature(base, URI, SubPos, Term, Vars).

--- a/prolog/pls_index/terms.pl
+++ b/prolog/pls_index/terms.pl
@@ -155,32 +155,3 @@ index_goal(URI, Caller, term_position(_From, _To, _FFrom, _FTo, Subpos), Goal) :
   arg(Index, Goal, Arg),
   nth1(Index, Subpos, Pos),
   index_goal(URI, Caller, Pos, Arg).
-
-functor_range(URI, term_position(_From, _To, FFrom, FTo, _Subpos), Range) :-
-  term_range(URI, FFrom, FTo, Range).
-
-functor_range(URI, FFrom, FTo, Range) :-
-  term_range(URI, FFrom, FTo, Range).
-
-term_position_range(URI, term_position(From, To, _FFrom, _FTo, _Subpos), Range) :-
-  term_range(URI, From, To, Range).
-
-term_range(URI, From, To, Range) :-
-  get_document_line_position(URI, FromLine, From),
-  get_document_line_position(URI, FromLine, FromStart),
-  get_document_line_position(URI, ToLine, To),
-  get_document_line_position(URI, ToLine, ToStart),
-  FromPosition is From - FromStart,
-  ToPosition is To - ToStart,
-  Range = range{
-    start: position{
-      line: FromLine,
-      character: FromPosition
-      }, 
-    end: position{
-      line: ToLine, 
-      character: ToPosition
-      }
-    }.
-
-argument_positions(term_position(_From, _To, _FFrom, _FTo, Subpos), Subpos).

--- a/prolog/pls_index/terms.pl
+++ b/prolog/pls_index/terms.pl
@@ -31,127 +31,19 @@ index_term(URI) :-
       variable_names(Vars)
       ]),
     ( Term \== end_of_file
-      -> (
-          index_term(URI, SubPos, Term),
-          term_position_range(URI, SubPos, Range),
-          index_comments(URI, Term, Range, CommentPos),
-          index_signature(URI, SubPos, Term, Vars)
-          )
+      -> process_term(URI, SubPos, Term, CommentPos, Vars)
       ; (!, fail)
       )
     )).
 
-%! index_term(+URI, +Pos, +Term) is nondet.
-%
-% Indexing the term at the indicated Position in the
-% source with the indicated URI.
-%
-index_term(URI, Pos, (:- module(Module, Exports))) :-
-  term_position_range(URI, Pos, Range),
-  add_document_item(URI, Range, module(Module, Exports)),
-  % Arg of :-, which is the term position for module
-  argument_positions(Pos, [DirectiveArgPos]),
-  % Args of module: first is the name, second is export list
-  argument_positions(DirectiveArgPos, [_,list_position(_,_,ExportPosList, _)]),
-  index_exports(URI, Exports, ExportPosList),
+process_term(URI, _SubPos, (:- use_language_profile(Profile)), _CommentPos, _Vars) :-
+  set_document_profile(URI, Profile),
   !.
 
-index_term(URI, Pos, (:- use_module(Module))) :-
-  term_position_range(URI, Pos, Range),
-  add_document_item(URI, Range, uses(Module)),
+process_term(URI, SubPos, Term, CommentPos, Vars) :-
+  get_document_profile(URI, Profile),
+  ensure_profile_loaded(Profile),
+  pls_index_profiles:profile_index_term(Profile, URI, SubPos, Term),
+  pls_index_profiles:profile_index_comments(Profile, URI, SubPos, Term, CommentPos),
+  pls_index_profiles:profile_index_signature(Profile, URI, SubPos, Term, Vars),
   !.
-
-index_term(URI, Pos, (:- reexport(Module))) :-
-  term_position_range(URI, Pos, Range),
-  add_document_item(URI, Range, reexports(Module)),
-  !.
-
-index_term(URI, Pos, (:- reexport(Module, Imports))) :-
-  term_position_range(URI, Pos, Range),
-  add_document_item(URI, Range, reexports(Module,Imports)),
-  !.
-
-index_term(URI, Pos, (:- [FileSpec])) :-
-  term_position_range(URI, Pos, Range),
-  add_document_item(URI, Range, loads(FileSpec)),
-  !.
-
-index_term(URI, Pos, (:- include(FileSpec) )) :-
-  term_position_range(URI, Pos, Range),
-  add_document_item(URI, Range, includes(FileSpec)),
-  !.
-
-index_term(URI, Pos, (_Module:Head :- Body)) :-
-  index_term(URI, Pos, (Head :- Body)).
-
-index_term(URI, Pos, (Head :- Body)) :-
-  functor(Head, Name, Arity),
-  Caller = Name/Arity,
-  argument_positions(Pos, [HeadPos, BodyPos]),
-  term_position_range(URI, HeadPos, Range),
-  add_document_item(URI, Range, defines(Caller)),
-  index_goals(URI, Caller, BodyPos, Body),
-  !.
-
-index_term(URI, Pos, (Head --> Body)) :-
-  functor(Head, Name, Arity),
-  Caller = Name//Arity,
-  argument_positions(Pos, [HeadPos, BodyPos]),
-  term_position_range(URI, HeadPos, Range),
-  add_document_item(URI, Range, defines(Caller)),
-  index_goals(URI, Caller, BodyPos, Body),
-  !.
-
-
-%! index_comments(+URI, +CommentPos, +TermPos) is nondet.
-%
-% Index the documentation for the term at the indicated TermPos,
-% using the CommentPos from an earlier `read_term/3` call.
-%
-index_comments(URI, Term, Range, CommentPos) :-
-  index_docs(URI, Term, Range, CommentPos),
-  !.
-
-index_signature(URI, Pos, Head :- _Body, Vars) :-
-  with_output_to(string(Signature),
-    write_term(Head,[variable_names(Vars)])
-    ),
-  term_position_range(URI, Pos, Range),
-  functor(Head, Name, Arity),
-  add_document_item(URI, Range, signature(Name/Arity, Signature)).
-
-index_signature(_, _, _, _).
-
-%! index_exports(+URI, +Exports, +ExportPosList) is nondet.
-%
-% Index the exports in a module declaration.
-%
-index_exports(_URI, [], []).
-
-index_exports(URI, [Export | ExportRest], [ExportPos | ExportPosListRest]) :-
-  term_position_range(URI, ExportPos, Range),
-  add_document_item(URI, Range, exports(Export)),
-  index_exports(URI, ExportRest, ExportPosListRest).
-
-index_goals(URI, Caller, GoalPos, Goal) :-
-  forall(index_goal(URI, Caller, GoalPos, Goal), true).
-
-index_goal(URI, Caller, parentheses_term_position(_From, _To, ContentPos), Goal) :-
-  index_goal(URI, Caller, ContentPos, Goal).
-
-index_goal(URI, Caller, term_position(_From, _To, FFrom, FTo, _Subpos), Goal) :-
-  functor_range(URI, FFrom, FTo, Range),
-  ( Caller = _Name // _Arity
-    -> ( functor(Goal, Name, Arity), Predicate = Name//Arity) 
-    ; ( functor(Goal, Name, Arity), Predicate = Name/Arity)
-    ),
-  Item = references(Caller, Predicate),
-  debug("Adding item %w",[Item]),
-  add_document_item(URI, Range, Item) .
-
-index_goal(URI, Caller, term_position(_From, _To, _FFrom, _FTo, Subpos), Goal) :-
-  functor(Goal, _Name, Arity),
-  between(1, Arity, Index),
-  arg(Index, Goal, Arg),
-  nth1(Index, Subpos, Pos),
-  index_goal(URI, Caller, Pos, Arg).

--- a/prolog/pls_index/terms.pl
+++ b/prolog/pls_index/terms.pl
@@ -32,7 +32,7 @@ index_term(URI) :-
       ]),
     ( Term \== end_of_file
       -> process_term(URI, SubPos, Term, CommentPos, Vars)
-      ; (!, fail)
+      ; (try_process_end_of_file(URI), !, fail)
       )
     )).
 
@@ -68,3 +68,12 @@ try_profile_index_signature(Profile, URI, SubPos, Term, Vars) :-
 
 try_profile_index_signature(_Profile, URI, SubPos, Term, Vars) :-
   pls_index_profiles:profile_index_signature(base, URI, SubPos, Term, Vars).
+
+try_process_end_of_file(URI) :-
+  get_document_profile(URI, Profile),
+  ensure_profile_loaded(Profile),
+  pls_index_profiles:profile_end_of_file(Profile, URI),
+  !.
+
+try_process_end_of_file(URI) :-
+  pls_index_profiles:profile_end_of_file(base, URI).

--- a/prolog/pls_index/terms.pl
+++ b/prolog/pls_index/terms.pl
@@ -44,7 +44,7 @@ process_term(URI, SubPos, Term, CommentPos, Vars) :-
   get_document_profile(URI, Profile),
   ensure_profile_loaded(Profile),
   try_profile_index_term(Profile, URI, SubPos, Term),
-  try_profile_index_comments(Profile, URI, SubPos, Term, CommentPos),
+  try_profile_index_docs(Profile, URI, SubPos, Term, CommentPos),
   try_profile_index_signature(Profile, URI, SubPos, Term, Vars),
   !.
 
@@ -55,12 +55,12 @@ try_profile_index_term(Profile, URI, SubPos, Term) :-
 try_profile_index_term(_Profile, URI, SubPos, Term) :-
   pls_index_profiles:profile_index_term(base, URI, SubPos, Term).
 
-try_profile_index_comments(Profile, URI, SubPos, Term, CommentPos) :-
-  pls_index_profiles:profile_index_comments(Profile, URI, SubPos, Term, CommentPos),
+try_profile_index_docs(Profile, URI, SubPos, Term, CommentPos) :-
+  pls_index_profiles:profile_index_docs(Profile, URI, SubPos, Term, CommentPos),
   !.
 
-try_profile_index_comments(_Profile, URI, SubPos, Term, CommentPos) :-
-  pls_index_profiles:profile_index_comments(base, URI, SubPos, Term, CommentPos).
+try_profile_index_docs(_Profile, URI, SubPos, Term, CommentPos) :-
+  pls_index_profiles:profile_index_docs(base, URI, SubPos, Term, CommentPos).
 
 try_profile_index_signature(Profile, URI, SubPos, Term, Vars) :-
   pls_index_profiles:profile_index_signature(Profile, URI, SubPos, Term, Vars),

--- a/prolog/pls_language_profile/base.pl
+++ b/prolog/pls_language_profile/base.pl
@@ -66,6 +66,19 @@ pls_index_profiles:profile_index_term(base, URI, Pos, (Head --> Body)) :-
   index_goals(URI, Caller, BodyPos, Body),
   !.
 
+pls_index_profiles:profile_index_term(base, URI, Pos, _Module:Term) :-  
+  pls_index_profiles:profile_index_term(base, URI, Pos, Term),
+  !.
+
+pls_index_profiles:profile_index_term(base, URI, Pos, Term) :-  
+  functor(Term, Name, Arity),
+  atom_codes(Name, [Initial|_]),
+  code_type(Initial, prolog_atom_start),
+  Caller = Name/Arity,
+  term_position_range(URI, Pos, Range),
+  add_document_item(URI, Range, defines(Caller)),
+  !.
+
 pls_index_profiles:profile_index_docs(base, URI, SubPos, _Module:Head :- Body, CommentPos) :-
   pls_index_profiles:profile_index_docs(base, URI, SubPos, Head :- Body, CommentPos),
   !.

--- a/prolog/pls_language_profile/base.pl
+++ b/prolog/pls_language_profile/base.pl
@@ -2,6 +2,7 @@
 
 ]).
 
+:- use_module(library(log4p)).
 :- use_module('../pls_index').
 
 %! index_term(+URI, +Pos, +Term) is nondet.
@@ -84,6 +85,29 @@ pls_index_profiles:profile_index_signature(base, URI, Pos, Head :- _Body, Vars) 
   add_document_item(URI, Range, signature(Name/Arity, Signature)).
 
 pls_index_profiles:profile_index_signature(base, _, _, _, _).
+
+%! 
+% 
+% 
+pls_index_profiles:profile_index_goal(base, URI, Caller, parentheses_term_position(_From, _To, ContentPos), Goal) :-
+  index_goal(URI, Caller, ContentPos, Goal).
+
+pls_index_profiles:profile_index_goal(base, URI, Caller, term_position(_From, _To, FFrom, FTo, _Subpos), Goal) :-
+  functor_range(URI, FFrom, FTo, Range),
+  ( Caller = _Name // _Arity
+    -> ( functor(Goal, Name, Arity), Predicate = Name//Arity) 
+    ; ( functor(Goal, Name, Arity), Predicate = Name/Arity)
+    ),
+  Item = references(Caller, Predicate),
+  debug("Adding item %w",[Item]),
+  add_document_item(URI, Range, Item) .
+
+pls_index_profiles:profile_index_goal(base, URI, Caller, term_position(_From, _To, _FFrom, _FTo, Subpos), Goal) :-
+  functor(Goal, _Name, Arity),
+  between(1, Arity, Index),
+  arg(Index, Goal, Arg),
+  nth1(Index, Subpos, Pos),
+  index_goal(URI, Caller, Pos, Arg).
 
 %! index_exports(+URI, +Exports, +ExportPosList) is nondet.
 %

--- a/prolog/pls_language_profile/base.pl
+++ b/prolog/pls_language_profile/base.pl
@@ -66,10 +66,18 @@ pls_index_profiles:profile_index_term(base, URI, Pos, (Head --> Body)) :-
   index_goals(URI, Caller, BodyPos, Body),
   !.
 
-pls_index_profiles:profile_index_comments(base, URI, SubPos, Term, CommentPos) :-
-  term_position_range(URI, SubPos, Range),
-  index_docs(URI, Term, Range, CommentPos),
+pls_index_profiles:profile_index_docs(base, URI, SubPos, _Module:Head :- Body, CommentPos) :-
+  pls_index_profiles:profile_index_docs(base, URI, SubPos, Head :- Body, CommentPos),
   !.
+
+pls_index_profiles:profile_index_docs(base, URI, SubPos, Head :- _Body, CommentPos) :-
+  term_position_range(URI, SubPos, Range),  
+  functor(Head, Name, Arity),
+  Predicate = Name/Arity,
+  index_docs(URI, Predicate, Range, CommentPos),
+  !.
+
+pls_index_profiles:profile_index_docs(base, _URI, _SubPos, _Term, _CommentPos).
 
 pls_index_profiles:profile_index_signature(base, URI, Pos, Head :- _Body, Vars) :-
   with_output_to(string(Signature),

--- a/prolog/pls_language_profile/base.pl
+++ b/prolog/pls_language_profile/base.pl
@@ -1,0 +1,3 @@
+:- module(pls_language_support_profile_base, [
+
+]).

--- a/prolog/pls_language_profile/base.pl
+++ b/prolog/pls_language_profile/base.pl
@@ -109,6 +109,8 @@ pls_index_profiles:profile_index_goal(base, URI, Caller, term_position(_From, _T
   nth1(Index, Subpos, Pos),
   index_goal(URI, Caller, Pos, Arg).
 
+pls_index_profiles:profile_end_of_file(base, _URI).  
+
 %! index_exports(+URI, +Exports, +ExportPosList) is nondet.
 %
 % Index the exports in a module declaration.

--- a/prolog/pls_language_profile/base.pl
+++ b/prolog/pls_language_profile/base.pl
@@ -1,3 +1,3 @@
-:- module(pls_language_support_profile_base, [
+:- module(pls_language_profile_base, [
 
 ]).

--- a/prolog/pls_language_profile/base.pl
+++ b/prolog/pls_language_profile/base.pl
@@ -108,13 +108,6 @@ pls_index_profiles:profile_index_signature(base, URI, Pos, Head :- _Body, Vars) 
 
 pls_index_profiles:profile_index_signature(base, _, _, _, _).
 
-pls_index_profiles:profile_index_goal(base, URI, Caller, SubPos, (Goal, MoreGoals) ) :-
-  info("In %w indexing goal %w",[URI, Goal]),
-  argument_positions(SubPos, [GoalPos, MoreGoalsPos]),
-  index_goal(URI, Caller, GoalPos, Goal),
-  !,
-  index_goal(URI, Caller, MoreGoalsPos, MoreGoals).
-
 pls_index_profiles:profile_index_goal(base, URI, Caller, SubPos, _Module:Goal) :-
   argument_positions(SubPos, [_ModulePos, GoalPos]),
   index_goal(URI, Caller, GoalPos, Goal),
@@ -129,6 +122,8 @@ pls_index_profiles:profile_index_goal(base, URI, Caller, term_position(_From, _T
     -> ( functor(Goal, Name, Arity), Predicate = Name//Arity) 
     ; ( functor(Goal, Name, Arity), Predicate = Name/Arity)
     ),
+  % Don't index references to this common fuctor, because its everywhere
+  Name \= ',',
   Item = references(Caller, Predicate),
   debug("Adding item %w",[Item]),
   add_document_item(URI, Range, Item) .
@@ -146,15 +141,15 @@ pls_index_profiles:profile_end_of_file(base, _URI).
 %
 % Index a declaration from a directive.
 %
-index_declaration(URI, Pos, Directive, (Caller, MoreCallers)) :-
+index_declaration(URI, Pos, Directive, (Predicate, MorePredicates)) :-
   argument_positions(Pos, [ArgPos, MoreArgsPos]),
-  index_declaration(URI, ArgPos, Directive, Caller),
-  index_declaration(URI, MoreArgsPos, Directive, MoreCallers).
+  index_declaration(URI, ArgPos, Directive, Predicate),
+  index_declaration(URI, MoreArgsPos, Directive, MorePredicates).
 
-index_declaration(URI, Pos, _Directive, Caller) :-
+index_declaration(URI, Pos, _Directive, Predicate) :-
   argument_positions(Pos, [ArgPos]),
   term_position_range(URI, ArgPos, Range),
-  add_document_item(URI, Range, defines(Caller)).
+  add_document_item(URI, Range, defines(Predicate)).
 
 %! index_exports(+URI, +Exports, +ExportPosList) is nondet.
 %

--- a/prolog/pls_language_profile/base.pl
+++ b/prolog/pls_language_profile/base.pl
@@ -46,7 +46,7 @@ pls_index_profiles:profile_index_term(base, URI, Pos, (:- include(FileSpec) )) :
   !.
 
 pls_index_profiles:profile_index_term(base, URI, Pos, (_Module:Head :- Body)) :-
-  index_term(URI, Pos, (Head :- Body)).
+  pls_index_profiles:profile_index_term(base, URI, Pos, (Head :- Body)).
 
 pls_index_profiles:profile_index_term(base, URI, Pos, (Head :- Body)) :-
   functor(Head, Name, Arity),
@@ -66,11 +66,6 @@ pls_index_profiles:profile_index_term(base, URI, Pos, (Head --> Body)) :-
   index_goals(URI, Caller, BodyPos, Body),
   !.
 
-%! index_comments(+URI, +CommentPos, +TermPos) is nondet.
-%
-% Index the documentation for the term at the indicated TermPos,
-% using the CommentPos from an earlier `read_term/3` call.
-%
 pls_index_profiles:profile_index_comments(base, URI, SubPos, Term, CommentPos) :-
   term_position_range(URI, SubPos, Range),
   index_docs(URI, Term, Range, CommentPos),
@@ -86,9 +81,6 @@ pls_index_profiles:profile_index_signature(base, URI, Pos, Head :- _Body, Vars) 
 
 pls_index_profiles:profile_index_signature(base, _, _, _, _).
 
-%! 
-% 
-% 
 pls_index_profiles:profile_index_goal(base, URI, Caller, parentheses_term_position(_From, _To, ContentPos), Goal) :-
   index_goal(URI, Caller, ContentPos, Goal).
 

--- a/prolog/pls_language_profile/base.pl
+++ b/prolog/pls_language_profile/base.pl
@@ -1,3 +1,97 @@
 :- module(pls_language_profile_base, [
 
 ]).
+
+:- use_module('../pls_index').
+
+%! index_term(+URI, +Pos, +Term) is nondet.
+%
+% Indexing the term at the indicated Position in the
+% source with the indicated URI.
+%
+pls_index_profiles:profile_index_term(base, URI, Pos, (:- module(Module, Exports))) :-
+  term_position_range(URI, Pos, Range),
+  add_document_item(URI, Range, module(Module, Exports)),
+  % Arg of :-, which is the term position for module
+  argument_positions(Pos, [DirectiveArgPos]),
+  % Args of module: first is the name, second is export list
+  argument_positions(DirectiveArgPos, [_,list_position(_,_,ExportPosList, _)]),
+  index_exports(URI, Exports, ExportPosList),
+  !.
+
+pls_index_profiles:profile_index_term(base, URI, Pos, (:- use_module(Module))) :-
+  term_position_range(URI, Pos, Range),
+  add_document_item(URI, Range, uses(Module)),
+  !.
+
+pls_index_profiles:profile_index_term(base, URI, Pos, (:- reexport(Module))) :-
+  term_position_range(URI, Pos, Range),
+  add_document_item(URI, Range, reexports(Module)),
+  !.
+
+pls_index_profiles:profile_index_term(base, URI, Pos, (:- reexport(Module, Imports))) :-
+  term_position_range(URI, Pos, Range),
+  add_document_item(URI, Range, reexports(Module,Imports)),
+  !.
+
+pls_index_profiles:profile_index_term(base, URI, Pos, (:- [FileSpec])) :-
+  term_position_range(URI, Pos, Range),
+  add_document_item(URI, Range, loads(FileSpec)),
+  !.
+
+pls_index_profiles:profile_index_term(base, URI, Pos, (:- include(FileSpec) )) :-
+  term_position_range(URI, Pos, Range),
+  add_document_item(URI, Range, includes(FileSpec)),
+  !.
+
+pls_index_profiles:profile_index_term(base, URI, Pos, (_Module:Head :- Body)) :-
+  index_term(URI, Pos, (Head :- Body)).
+
+pls_index_profiles:profile_index_term(base, URI, Pos, (Head :- Body)) :-
+  functor(Head, Name, Arity),
+  Caller = Name/Arity,
+  argument_positions(Pos, [HeadPos, BodyPos]),
+  term_position_range(URI, HeadPos, Range),
+  add_document_item(URI, Range, defines(Caller)),
+  index_goals(URI, Caller, BodyPos, Body),
+  !.
+
+pls_index_profiles:profile_index_term(base, URI, Pos, (Head --> Body)) :-
+  functor(Head, Name, Arity),
+  Caller = Name//Arity,
+  argument_positions(Pos, [HeadPos, BodyPos]),
+  term_position_range(URI, HeadPos, Range),
+  add_document_item(URI, Range, defines(Caller)),
+  index_goals(URI, Caller, BodyPos, Body),
+  !.
+
+%! index_comments(+URI, +CommentPos, +TermPos) is nondet.
+%
+% Index the documentation for the term at the indicated TermPos,
+% using the CommentPos from an earlier `read_term/3` call.
+%
+pls_index_profiles:profile_index_comments(base, URI, SubPos, Term, CommentPos) :-
+  term_position_range(URI, SubPos, Range),
+  index_docs(URI, Term, Range, CommentPos),
+  !.
+
+pls_index_profiles:profile_index_signature(base, URI, Pos, Head :- _Body, Vars) :-
+  with_output_to(string(Signature),
+    write_term(Head,[variable_names(Vars)])
+    ),
+  term_position_range(URI, Pos, Range),
+  functor(Head, Name, Arity),
+  add_document_item(URI, Range, signature(Name/Arity, Signature)).
+
+pls_index_profiles:profile_index_signature(base, _, _, _, _).
+
+%! index_exports(+URI, +Exports, +ExportPosList) is nondet.
+%
+% Index the exports in a module declaration.
+%
+index_exports(_URI, [], []).
+
+index_exports(URI, [Export | ExportRest], [ExportPos | ExportPosListRest]) :-
+  term_position_range(URI, ExportPos, Range),
+  add_document_item(URI, Range, exports(Export)),
+  index_exports(URI, ExportRest, ExportPosListRest).

--- a/prolog/prolog_lsp.pl
+++ b/prolog/prolog_lsp.pl
@@ -16,3 +16,8 @@
 :- use_module(methods).
 :- reexport(language_server).
 :- reexport(language_client).
+:- use_module(pls_index/profiles).
+
+% We load the base profile by default
+:- use_module(pls_language_profile/base).
+:- assertz(pls_index_profiles:profile_loaded(base)).


### PR DESCRIPTION
Language profiles enable specialization of the language server's indexing. The expected use case is when a library or program sufficiently tailors Prolog with a domain specific language (DSL), and standard or _base_ prolog indexing does not extract rich enough data.